### PR TITLE
fix/uptime: encode only when it is unicode

### DIFF
--- a/library/statuscake_uptime.py
+++ b/library/statuscake_uptime.py
@@ -388,10 +388,9 @@ class StatusCakeUptime:
                     if k in self.data.keys()})
         for key in req_data.keys():
             if type(req_data[key]) is list:
-                req_data[key] = [item.encode('UTF8') for item in req_data[key]]
-                req_data[key] = ','.join(req_data[key])
+                req_data[key] = to_native(','.join(req_data[key]))
             if type(req_data[key]) is unicode:
-                req_data[key] = req_data[key].encode('UTF-8')
+                req_data[key] = to_native(req_data[key])
             if req_data[key] is True:
                 req_data[key] = 1
             if req_data[key] is False:

--- a/library/statuscake_uptime.py
+++ b/library/statuscake_uptime.py
@@ -387,9 +387,9 @@ class StatusCakeUptime:
         req_data = ({k: req_data[k] for k in req_data.keys()
                     if k in self.data.keys()})
         for key in req_data.keys():
-            if type(req_data[key]) is list:
+            if isinstance(req_data[key],list):
                 req_data[key] = to_native(','.join(req_data[key]))
-            if type(req_data[key]) is unicode:
+            if isinstance(req_data[key],unicode):
                 req_data[key] = to_native(req_data[key])
             if req_data[key] is True:
                 req_data[key] = 1


### PR DESCRIPTION
* encode characters only when it is unicode
* use `isinstance()` instead `type()` as best practices