### PR TITLE
fix/json: request response error handling and timeout

### DIFF
--- a/library/statuscake_ssl.py
+++ b/library/statuscake_ssl.py
@@ -253,8 +253,8 @@ class StatusCakeSSL:
 
         try:
             return self.module.from_json(to_native(resp.read()))
-        except AttributeError:
-            return self.module.from_json(to_native(info))
+        except:
+            return self.module.fail_json(msg=info)
 
 
 def run_module():

--- a/library/statuscake_ssl.py
+++ b/library/statuscake_ssl.py
@@ -243,7 +243,9 @@ class StatusCakeSSL:
         resp, info = fetch_url(self.module, self.url,
                                headers=self.headers,
                                data=payload,
-                               method=self.method)
+                               method=self.method,
+                               timeout=20
+                               )
 
         if info['status'] >= (500 or -1):
             self.module.fail_json(msg='Request failed for {url}: {status} - {msg}'.format(**info))

--- a/library/statuscake_uptime.py
+++ b/library/statuscake_uptime.py
@@ -409,7 +409,9 @@ class StatusCakeUptime:
         resp, info = fetch_url(self.module, self.url,
                                headers=self.headers,
                                data=payload,
-                               method=self.method)
+                               method=self.method,
+                               timeout=20
+                               )
 
         if info['status'] >= (500 or -1):
             self.module.fail_json(msg='Request failed for {url}: {status} - {msg}'.format(**info))

--- a/library/statuscake_uptime.py
+++ b/library/statuscake_uptime.py
@@ -419,8 +419,8 @@ class StatusCakeUptime:
 
         try:
             return self.module.from_json(to_native(resp.read()))
-        except AttributeError:
-            return self.module.from_json(to_native(info))
+        except:
+            return self.module.fail_json(msg=info)
 
 
 def run_module():


### PR DESCRIPTION
* fix `request()` response error handling from both modules (uptime and ssl)
* sometimes module got read timeout from StatusCake API so I'vw increases urllib timeout from 10 to 20 seconds